### PR TITLE
MongoDB Stitch & Global Search Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2121,8 +2121,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -2386,6 +2385,26 @@
         "https-proxy-agent": "^2.2.1"
       }
     },
+    "bson": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+      "requires": {
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -2412,6 +2431,11 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -3732,6 +3756,11 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "detect-browser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.1.tgz",
+      "integrity": "sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw=="
+    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
@@ -3886,6 +3915,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -5295,8 +5332,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -6139,6 +6175,23 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "requires": {
+        "jws": "^3.1.4",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "xtend": "^4.0.1"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6161,6 +6214,25 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "karma": {
@@ -6380,11 +6452,46 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -6419,6 +6526,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
       "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
       "dev": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -6964,6 +7076,54 @@
         }
       }
     },
+    "mongodb-stitch-browser-core": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-core/-/mongodb-stitch-browser-core-4.8.0.tgz",
+      "integrity": "sha512-tKzNW+w6VFQOS+opbC8lPjmgJx8H+/4s8qIwM2fcH+GUti+J6hcj3b8Eei7VcyHiWYNsS8S0cx+BypOmILhfeg==",
+      "requires": {
+        "bson": "4.0.2",
+        "detect-browser": "^3.0.0",
+        "mongodb-stitch-core-sdk": "^4.8.0",
+        "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "mongodb-stitch-browser-sdk": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-sdk/-/mongodb-stitch-browser-sdk-4.8.0.tgz",
+      "integrity": "sha512-+u5OOwxhGFee2JiS/ocVqR4OQw5wEKCH99w0CJz9l5NqNpQeR1VZRt9HmMLk7k9fn4/LaL5QcdalzA9YA+T8eA==",
+      "requires": {
+        "mongodb-stitch-browser-core": "^4.8.0",
+        "mongodb-stitch-browser-services-mongodb-remote": "^4.8.0"
+      }
+    },
+    "mongodb-stitch-browser-services-mongodb-remote": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-browser-services-mongodb-remote/-/mongodb-stitch-browser-services-mongodb-remote-4.8.0.tgz",
+      "integrity": "sha512-LPtuOufHKzrATNJB+DAdK0LYRvoVaAI+3Oobqx9FI9WAjNY22lwHiJQ7FBFejSEz1YL7Nap6f7Z2P2DlYr0WsA==",
+      "requires": {
+        "mongodb-stitch-browser-core": "^4.8.0",
+        "mongodb-stitch-core-services-mongodb-remote": "^4.8.0"
+      }
+    },
+    "mongodb-stitch-core-sdk": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-core-sdk/-/mongodb-stitch-core-sdk-4.8.0.tgz",
+      "integrity": "sha512-IK6Yh8mGsX7zzgbk6l/4xt8lxYORpEc/rWSaZoNo70h+u0gBcNlOes6TdlqYgzi5Q/mT0gqWI9jhInrg0IvnGQ==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "bson": "4.0.2",
+        "jsonwebtoken": "8.2.1"
+      }
+    },
+    "mongodb-stitch-core-services-mongodb-remote": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb-stitch-core-services-mongodb-remote/-/mongodb-stitch-core-services-mongodb-remote-4.8.0.tgz",
+      "integrity": "sha512-sxhmUqXlcn5152vqyoN7tQnowNKMSHUVms0rXOWXMVoHGf5eK+kqhtuT4haz/daa0pwR9L50NKYBRxOLt3phRg==",
+      "requires": {
+        "bson": "4.0.2",
+        "mongodb-stitch-core-sdk": "^4.8.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6992,8 +7152,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -9335,8 +9494,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13058,6 +13216,11 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
     "when": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
@@ -13175,8 +13338,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "~9.0.3",
     "@angular/platform-browser-dynamic": "~9.0.3",
     "@angular/router": "~9.0.3",
+    "mongodb-stitch-browser-sdk": "^4.8.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,3 @@
-<div [class.dark-theme]="theme === 1">
-  <app-header></app-header>
-  <router-outlet></router-outlet>
-  <app-footer></app-footer>
-</div>
+<app-header></app-header>
+<router-outlet></router-outlet>
+<app-footer></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ContentService } from './shared/content/content.service';
 import { ETheme } from './contracts/shared/theme';
+import { ContentService } from './shared/content/content.service';
 
 @Component({
   selector: 'app-root',
@@ -9,13 +9,24 @@ import { ETheme } from './contracts/shared/theme';
 })
 export class AppComponent implements OnInit {
   title = 'angular-starters';
-  theme: ETheme;
 
   constructor(private contentService: ContentService) { }
 
   ngOnInit(): void {
     // Subscribe to any theme changes.
-    this.contentService.theme$.subscribe((theme: ETheme) => this.theme = theme);
+    this.contentService.theme$.subscribe((theme: ETheme) => {
+      let body = document.body;
+      // Set the theme to dark or light.
+      if (theme === ETheme.Dark) {
+        if (!body.classList.contains('dark-theme')) {
+          body.classList.add('dark-theme');
+        }
+      } else {
+        if (body.classList.contains('dark-theme')) {
+          body.classList.remove('dark-theme');
+        }
+      }
+    });
   }
 
 }

--- a/src/app/contracts/search/iglobal-search-result.ts
+++ b/src/app/contracts/search/iglobal-search-result.ts
@@ -1,0 +1,7 @@
+import { ISearchResult } from './isearch-result';
+
+export interface IGlobalSearchResult {
+  _id: 'starter' | 'theme' | 'site';
+  avgScore: number;
+  results: ISearchResult[];
+}

--- a/src/app/contracts/search/ihighlight.ts
+++ b/src/app/contracts/search/ihighlight.ts
@@ -1,0 +1,8 @@
+export interface IHighlight {
+  path: string;
+  texts: {
+    value: string;
+    type: string;
+  }[];
+  score: number;
+}

--- a/src/app/contracts/search/iprevious-global-search-queries.ts
+++ b/src/app/contracts/search/iprevious-global-search-queries.ts
@@ -1,0 +1,3 @@
+export interface IPreviousGlobalSearchQueries {
+  queries: string[];
+}

--- a/src/app/contracts/search/isearch-result.ts
+++ b/src/app/contracts/search/isearch-result.ts
@@ -1,0 +1,7 @@
+import { IHighlight } from './ihighlight';
+
+export interface ISearchResult {
+  name: string;
+  score: number;
+  highlights: IHighlight[];
+}

--- a/src/app/contracts/shared/theme.ts
+++ b/src/app/contracts/shared/theme.ts
@@ -9,6 +9,7 @@ export interface IThemeConfig {
 }
 
 export interface ITheme {
+  theme: string;
   logoUrl: string;
   headerLogoUrl: string;
   themeIcon: string;

--- a/src/app/core/header/header-buttons/header-buttons.component.html
+++ b/src/app/core/header/header-buttons/header-buttons.component.html
@@ -1,4 +1,3 @@
 <a mat-button class="header-button" routerLink="/starters">Starters</a>
 <a mat-button class="header-button" routerLink="/themes">Themes</a>
 <a mat-button class="header-button" routerLink="/sites">Sites</a>
-<a mat-button class="header-button" routerLink="/about">About</a>

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -11,8 +11,36 @@
     <span class="header-spacer"></span>
     
     <mat-form-field class="search-form-field" appearance="fill">
-      <input matInput placeholder="Search">
+      <input matInput placeholder="Search" (input)="typeahead($event)" [(ngModel)]="searchTerm" [matAutocomplete]="searchResultsGroup">
       <mat-icon matSuffix>search</mat-icon>
+      <mat-autocomplete [ngClass]="{ 'dark-theme': currentTheme.theme === 'dark' }" (optionSelected)="saveAndSearch($event)" #searchResultsGroup="matAutocomplete">
+        <ng-container *ngIf="searchTerm === '' && globalSearchResults.length === 0 && previousGlobalSearchQueries.length > 0; else searching">
+          <mat-optgroup label="Previous Searches">
+            <mat-option *ngFor="let query of previousGlobalSearchQueries"  (click)="saveAndSearch($event)" (key.enter)="saveAndSearch($event)" [value]="query">
+              {{ query }}
+            </mat-option>
+          </mat-optgroup>
+        </ng-container>
+        <ng-template #searching>
+          <mat-optgroup class="search-results" *ngFor="let group of globalSearchResults" [label]="mappedNames[group._id].name">
+            <mat-option *ngFor="let result of group.results" (click)="saveAndSearch($event)" [value]="result.name">
+              <div *ngIf="result.highlights.length === 1">
+                {{ result.name }}
+              </div>
+              <div *ngFor="let highlight of result.highlights">
+                <ng-container *ngFor="let text of highlight.texts">
+                  <ng-container *ngIf="text.type === 'hit'; else noHit">
+                    <span class="hit">{{ text.value }}</span>
+                  </ng-container>
+                  <ng-template #noHit>
+                    {{ text.value }}
+                  </ng-template>
+                </ng-container>
+              </div>
+            </mat-option>
+          </mat-optgroup>
+        </ng-template>
+      </mat-autocomplete>
     </mat-form-field>
     <button mat-button (click)="toggleTheme($event)" class="theme-icon-button"><mat-icon class="theme-icon">{{ currentTheme.themeIcon }}</mat-icon></button>
   </div>

--- a/src/app/core/header/header.component.ts
+++ b/src/app/core/header/header.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { IPreviousGlobalSearchQueries } from '../../contracts/search/iprevious-global-search-queries';
 import { ITheme } from '../../contracts/shared/theme';
+import { SearchService } from '../../services/search.service';
 import { ContentService } from '../../shared/content/content.service';
 
 @Component({
@@ -11,12 +13,33 @@ import { ContentService } from '../../shared/content/content.service';
 export class HeaderComponent implements OnInit, OnDestroy {
   private unsubscribe: Subject<any> = new Subject<any>();
   currentTheme: ITheme;
+  readonly mappedNames: object = {
+    starter: {
+      name: 'Starters',
+      baseUrl: '/starter/'
+    },
+    theme:{
+      name: 'Theme',
+      baseUrl: '/theme/'
+    },
+    site: {
+      name: 'Site',
+      baseUrl: '/site/'
+    }
+  };
+  previousGlobalSearchQueries: {}[] = []
+  globalSearchResults: {}[] = [];
+  searchTerm: string = '';
 
-  constructor(private contentService: ContentService) { }
+  constructor(private contentService: ContentService,
+              private searchService: SearchService) { }
 
   ngOnInit(): void {
     // Subscribe to any theme changes.
     this.contentService.currentThemeConfig$.pipe(takeUntil(this.unsubscribe)).subscribe((theme: ITheme) => this.currentTheme = theme);
+    // Get any previous global search queries from the user's local storage.
+    const previousGlobalSearchQueries: { queries: string[] } = this.getPreviousGlobalSearchQueries();
+    this.previousGlobalSearchQueries = (previousGlobalSearchQueries ? previousGlobalSearchQueries.queries : []).reverse();
   }
 
   /**
@@ -25,6 +48,62 @@ export class HeaderComponent implements OnInit, OnDestroy {
    */
   toggleTheme(event: MouseEvent): void {
     this.contentService.toggleTheme();
+  }
+
+  /**
+   * Gets the previous global search queries from local storage.
+   * @returns {IPreviousGlobalSearchQueries}
+   */
+  getPreviousGlobalSearchQueries(): IPreviousGlobalSearchQueries {
+    return JSON.parse(localStorage.getItem('previousGlobalSearchQueries'));
+  }
+
+  /**
+   * Performs typeahead search.
+   * @param {KeyboardEvent} event 
+   */
+  typeahead(event: KeyboardEvent): void {
+    this.search(this.searchTerm);
+  }
+
+  /**
+   * If a user clicks or presses the enter key on a search result, it will save
+   * their search query in local storage and perform a search.
+   * @param {MouseEvent} event 
+   */
+  saveAndSearch(event: MouseEvent): void {
+    let previousGlobalSearchQueries = [].concat(this.getPreviousGlobalSearchQueries() ? this.getPreviousGlobalSearchQueries().queries : []);
+    if (!previousGlobalSearchQueries.includes(this.searchTerm)) {
+      previousGlobalSearchQueries.push(this.searchTerm);
+    } else {
+      previousGlobalSearchQueries.splice(previousGlobalSearchQueries.indexOf(this.searchTerm), 1);
+      previousGlobalSearchQueries.push(this.searchTerm);
+    }
+    if (previousGlobalSearchQueries.length > 10) {
+      previousGlobalSearchQueries.slice(0, 10);
+    }
+    localStorage.setItem('previousGlobalSearchQueries', JSON.stringify({
+      queries: previousGlobalSearchQueries
+    }));
+    this.previousGlobalSearchQueries = previousGlobalSearchQueries.reverse();
+    this.search(this.searchTerm);
+  }
+
+  /**
+   * Performs a search based on the search term only if the user has provided
+   * more than 3 characters in the search term.
+   * @param {string} searchTerm 
+   */
+  search(searchTerm: string): void {
+    if (searchTerm.length >= 3) {
+      this.searchService.globalSearch(searchTerm).subscribe((result: {}[]) => {
+        this.globalSearchResults = result;
+      }, (error) => {
+        console.log(error);
+      });
+    } else {
+      this.globalSearchResults = [];
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/client.service.spec.ts
+++ b/src/app/services/client.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ClientService } from './client.service';
+
+describe('ClientService', () => {
+  let service: ClientService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ClientService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/client.service.ts
+++ b/src/app/services/client.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { AnonymousCredential, RemoteMongoClient, Stitch, StitchAppClient } from 'mongodb-stitch-browser-sdk';
+import { environment } from '../../environments/environment';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClientService {
+  // Client variable to use in multiple services.
+  protected readonly client: StitchAppClient = Stitch.initializeDefaultAppClient(environment.stitchClientName);
+  // MongoDB variable used for accessing collections from a database.
+  protected readonly mongodb: RemoteMongoClient = this.client.getServiceClient(RemoteMongoClient.factory, environment.stitchServiceName);
+
+  constructor() {
+    // By default log the user in anonymously.
+    Stitch.defaultAppClient.auth.loginWithCredential(new AnonymousCredential()).catch(console.error);
+  }
+
+  /**
+   * Make the client variable shareable.
+   * @returns {StitchAppClient}
+   */
+  get getClient(): StitchAppClient {
+    return this.client;
+  }
+
+  /**
+   * Make the mongodb variable shareable.
+   * @returns {RemoteMongoClient}
+   */
+  get getMongoDB(): RemoteMongoClient {
+    return this.mongodb;
+  }
+  
+}

--- a/src/app/services/search.service.spec.ts
+++ b/src/app/services/search.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SearchService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@angular/core';
+import { StitchAppClient } from 'mongodb-stitch-browser-sdk';
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { IGlobalSearchResult } from '../contracts/search/iglobal-search-result';
+import { ISearchResult } from '../contracts/search/isearch-result';
+import { ClientService } from './client.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchService {
+  // Client variable to use in the service.
+  private readonly client: StitchAppClient;
+  // Variable with access to the all data collection.
+  private allDataCollection;
+
+  constructor(private clientService: ClientService) {
+    // Get the shareable client to use in this service.
+    this.client = clientService.getClient;
+    // Set the database.
+    const mongodb = clientService.getMongoDB;
+    // Set the all data collection.
+    this.allDataCollection = mongodb.db(environment.startersDB).collection(environment.allDataCollection);
+  }
+
+  /**
+   * Performs global search on starters, themes, and sites.
+   * @param {string} query 
+   * @returns {Observable<IGlobalSearchResult[]>}
+   */
+  globalSearch(query: string): Observable<IGlobalSearchResult[]> {
+    // Create the pipeline.
+    const pipeline = [
+      {
+        '$searchBeta': {
+          'search': {
+            'query': query, 
+            'path': [
+              'description', 'name'
+            ]
+          }, 
+          'highlight': {
+            'path': [
+              'name', 'description'
+            ]
+          }
+        }
+      }, {
+        '$project': {
+          'type': 1, 
+          'name': 1, 
+          'description': 1, 
+          'score': {
+            '$meta': 'searchScore'
+          }, 
+          'highlights': {
+            '$meta': 'searchHighlights'
+          }
+        }
+      }, {
+        '$group': {
+          '_id': '$type', 
+          'avgScore': {
+            '$avg': '$score'
+          }, 
+          'results': {
+            '$push': {
+              'name': '$name', 
+              'score': '$score', 
+              'highlights': '$highlights'
+            }
+          }
+        }
+      }
+    ];
+
+    // Perform search.
+    return from(this.allDataCollection.aggregate(pipeline).toArray())
+    .pipe(map((searchResults: IGlobalSearchResult[]) => {
+      // Limit the search results in the drop down depending on the number of
+      // each type of starter returns.
+      switch (searchResults.length) {
+        case 3: {
+          searchResults = this.sliceHighlights(searchResults, 3);
+        };
+        case 2: {
+          searchResults = this.sliceHighlights(searchResults, 5);
+        };
+        case 1: {
+          searchResults = this.sliceHighlights(searchResults, 10);
+        };
+        default: {
+          searchResults = this.sliceHighlights(searchResults, 3);
+        };
+      };
+      return searchResults;
+    }));
+  }
+
+  /**
+   * Reusable method for slicing the highlighted results in order to limit
+   * the number of results depending on how many of each type of starter is
+   * returned.
+   * @param {IGlobalSearchResult[]} searchResults 
+   * @param {number} end 
+   * @returns {IGlobalSearchResult[]}
+   */
+  sliceHighlights(searchResults: IGlobalSearchResult[], end: number): IGlobalSearchResult[] {
+    return searchResults.map((searchResult: IGlobalSearchResult) => {
+      return {
+        ...searchResult,
+        results: searchResult.results.map((result: ISearchResult) => {
+          result.highlights = result.highlights.slice(0, end);
+          return result;
+        })
+      };
+    });
+  }
+
+}

--- a/src/app/shared/content/content.service.ts
+++ b/src/app/shared/content/content.service.ts
@@ -10,6 +10,7 @@ export class ContentService {
   public theme$: Observable<ETheme> = this.theme.asObservable();
   private readonly themeConfig: IThemeConfig = {
     0: {
+      theme: 'light',
       logoUrl: '/assets/logo_light_theme.png',
       headerLogoUrl: '/assets/header_logo_light_theme.png',
       themeIcon: 'brightness_3',
@@ -18,6 +19,7 @@ export class ContentService {
       linkedinIcon: '/assets/linkedin_light_theme.png'
     },
     1: {
+      theme: 'dark',
       logoUrl: '/assets/logo_dark_theme.png',
       headerLogoUrl: '/assets/header_logo_dark_theme.png',
       themeIcon: 'wb_sunny',

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -1,14 +1,17 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
+
 @NgModule({
   imports: [
     CommonModule,
+    MatAutocompleteModule,
     MatButtonModule,
     MatFormFieldModule,
     MatIconModule,
@@ -16,6 +19,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatToolbarModule
   ],
   exports: [
+    MatAutocompleteModule,
     MatButtonModule,
     MatFormFieldModule,
     MatIconModule,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,18 +1,27 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { ClientService } from '../services/client.service';
+import { SearchService } from '../services/search.service';
 import { MaterialModule } from './material.module';
 
 @NgModule({
   declarations: [],
   imports: [
     CommonModule,
-    MaterialModule,
-    RouterModule
-  ],
-  exports: [
+    FormsModule,
     MaterialModule,
     RouterModule,
+  ],
+  exports: [
+    FormsModule,
+    MaterialModule,
+    RouterModule,
+  ],
+  providers: [
+    ClientService,
+    SearchService
   ]
 })
 export class SharedModule { }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,7 @@
 export const environment = {
-  production: true
+  production: true,
+  stitchClientName: 'angular_starters-lvzjv',
+  stitchServiceName: 'angular-starters',
+  startersDB: 'starters',
+  allDataCollection: 'all-data'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,11 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  stitchClientName: 'angular_starters-lvzjv',
+  stitchServiceName: 'angular-starters',
+  startersDB: 'starters',
+  allDataCollection: 'all-data'
 };
 
 /*

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -61,3 +61,5 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+// Needed to fix MongoDB Stitch "global not defined" error
+(window as any).global = window;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -262,3 +262,4 @@ p {
 @import './styles/components/home/submit-starter.component.scss';
 @import './styles/components/footer.component.scss';
 @import './styles/components/header.component';
+@import './styles/components/search.component.scss';

--- a/src/styles/components/footer.component.scss
+++ b/src/styles/components/footer.component.scss
@@ -1,10 +1,12 @@
 .footer-container {
   display: flex;
-  justify-content: space-around;
-  padding: 4em;
+  justify-content: space-between;
+  padding: 4em 12em;
+  @include belowDesktop {
+    padding: 4em;
+  }
   @include belowTablet {
     flex-direction: column;
-    justify-content: space-between;
   }
   .link-section {
     display: flex;

--- a/src/styles/components/header.component.scss
+++ b/src/styles/components/header.component.scss
@@ -99,8 +99,11 @@ $button-margin-left-below-desktop: .5em;
   }
   .search-form-field {
     font-size: .7em;
-    @include aboveIpad {
-      width: 350px;
+    @include aboveDesktop {
+      width: 600px;
+    }
+    @include belowDesktop {
+      width: 500px;
     }
     @include belowIpad {
       margin: 0 .5em;

--- a/src/styles/components/search.component.scss
+++ b/src/styles/components/search.component.scss
@@ -1,0 +1,74 @@
+$light-border-color: rgba(0, 0, 0, 0.06);
+
+.hit {
+  color: $primary-color;
+  font-weight: 400;
+  text-decoration: underline;
+  .dark-theme & {
+    color: white !important;
+  }
+}
+.mat-autocomplete-panel {
+  .dark-theme & {
+    background: #373d45 !important;
+  }
+}
+.mat-optgroup-label {
+  color: black;
+  font-weight: 400;
+  font-size: 1.5em;
+  .dark-theme & {
+    color: white !important;
+  }
+}
+.mat-option { 
+  padding: 0 1em !important;
+  .mat-option-text {
+    font-weight: 200;
+  }
+}
+.search-results {
+  .mat-optgroup-label {
+    border-bottom: 1px solid $light-border-color;
+    border-top: 1px solid $light-border-color;
+    .dark-theme & {
+      border-bottom: 1px solid white;
+      border-top: 1px solid white;
+    }
+  }
+  .mat-option {
+    height: auto !important;
+    line-height: 1.25em !important;
+    padding: 0 !important;
+    white-space: normal !important;
+    .mat-option-text {
+      display: flex !important;
+      justify-content: space-between;
+      @include belowIpad {
+        border-bottom: 1px solid $light-border-color;
+        flex-direction: column;
+      }
+      div {
+        &:nth-child(1) {
+          padding: 1em;
+          @include aboveIpad {
+            border-right: 1px solid $light-border-color;
+            width: 40%;
+          }
+          .dark-theme & {
+            border-right: 1px solid white;
+          }
+        }
+        &:nth-child(2) {
+          margin: 1em;
+          @include aboveIpad {
+            width: 55%;
+          }
+        }
+        .dark-theme & {
+          color: rgba(255, 255, 255, 0.733) !important;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adding MongoDB Stitch SDK
- Adding/Removing dark theme class to the body element rather than div to make the autocomplete search component a child of the dark theme class
- Removing the about header nav button
- Adding interfaces for global search results
- Making use of angular material's autocomplete for typeahead global search results
- Adding a client service for reusable client and collection access in the search  service
- Adding a search service for search service sdk calls
- Making the footer padding better with how we structure the page padding